### PR TITLE
Fixed link to Qualisys logo in the Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ROS Driver for Motion Capture Systems
 ![VICON Logo](http://www.awn.com/sites/default/files/styles/inline_medium/public/image/featured/1025139-vicon-delivers-motion-capture-innovations-siggraph-2015.jpg?itok=vsH7Prwo)
 
-![QUALISYS Logo](http://isbs2015.sciencesconf.org/conference/isbs2015/pages/Qualisys_Logga_PMS.png)
+![QUALISYS Logo](https://cdn-content.qualisys.com/2021/01/qualisys-logo-530x.png)
 
 This package contains ROS drivers for two different motion capture systems,**VICON** And **QUALISYS**.
 **NOTE:** This fork focuses on the Qualisys ROS driver. Some alterations have been made to the Vicon package to ensure compatability with the mutual interface.


### PR DESCRIPTION
Changed the link to one that is permanent.
Made the Logo be visually similar in size to the Vicon logo.