### PR TITLE
"User friendly" error message

### DIFF
--- a/mocap_base/src/MoCapDriverBase.cpp
+++ b/mocap_base/src/MoCapDriverBase.cpp
@@ -35,9 +35,14 @@ Subject::Subject(ros::NodeHandle* nptr, const string& sub_name,
   nh_ptr       (nptr),
   parent_frame (p_frame){
 
-  pub_filter = nh_ptr->advertise<nav_msgs::Odometry>(name+"/odom", 1);
-  pub_raw = nh_ptr->advertise<geometry_msgs::PoseStamped>(name+"/pose", 1);
-  pub_vel = nh_ptr->advertise<geometry_msgs::TwistStamped>(name+"/velocity", 1);
+  try {
+    pub_filter = nh_ptr->advertise<nav_msgs::Odometry>(name+"/odom", 1);
+    pub_raw = nh_ptr->advertise<geometry_msgs::PoseStamped>(name+"/pose", 1);
+    pub_vel = nh_ptr->advertise<geometry_msgs::TwistStamped>(name+"/velocity", 1);
+  } catch(ros::InvalidNameException e) {
+    ROS_ERROR_STREAM("Body name \"" << name << "\" cannot be used to create a valid ROS topic name. Try renaming it in QTM.");
+    throw e;
+  }
   return;
 }
 


### PR DESCRIPTION
Hi,

Following this issue #9, I did not "sanitize" the name as I did not know what to do with the invalid char (omit them ? replace them by another one ?  ... ?). 

Instead, I just added a more user-friendly error message for faster understanding of the error. (Changing the body name in QTM afterward is fast and easy and shouldn't cause any other problems).